### PR TITLE
Add stopwatch feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Kickstarter Campaign [Kickstarter](https://www.kickstarter.com/projects/theprint
     * DS1302 RTC
     * 4 Digit 7-segment display
     * 4 Programmable physical buttons
+    * Built-in stopwatch mode
   * 3D printed watch case
   * 12 Month+ Battery life
 


### PR DESCRIPTION
## Summary
- add STOPWATCH state
- implement stopwatch logic with start/stop/reset controls
- enter stopwatch via quick press of the hour button
- document stopwatch feature

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6878e5768da8832ea9b9dbdecd613d87